### PR TITLE
Updated netstandard version in example and test projects to work with AWS JSON Serialization library

### DIFF
--- a/DotnetCoreLambdaExample.Tests/DotnetCoreLambdaExample.Tests.csproj
+++ b/DotnetCoreLambdaExample.Tests/DotnetCoreLambdaExample.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DotnetCoreLambdaExample/DotnetCoreLambdaExample.csproj
+++ b/DotnetCoreLambdaExample/DotnetCoreLambdaExample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ Here are the most important patterns demonstrated here:
 
 ## Setup
 ### Prerequisites
-Make sure you've installed a version of the .NET Core SDK that supports `netstandard1.4` (for the Lambda function project) and `netcoreapp1.1` (for the unit test project).
+Make sure you've installed a version of the .NET Core SDK that supports `netstandard2.1` for the Lambda function project and the unit test project).
 
 ### Building and deploying the Lambda function
 1. Navigate to the directory the Lambda function's .csproj file is in (./DotnetCoreLambdaExample) and run `dotnet restore`


### PR DESCRIPTION
With the current configuration, you get this error running a `dotnet restore`:

> error NU1202: Package Amazon.Lambda.Serialization.Json 2.0.0 is not compatible with netstandard1.4

And according to AWS's dotnetcore docs here: https://aws.amazon.com/blogs/compute/announcing-aws-lambda-supports-for-net-core-3-1/ they support netstandard2.1, which is what I changed it to.